### PR TITLE
Improve initialization and finalization

### DIFF
--- a/src/lib/util/lifecycle.ts
+++ b/src/lib/util/lifecycle.ts
@@ -45,3 +45,28 @@ export class SignalConnectionTracker implements Destructible {
     }
   }
 }
+
+/**
+ * A destroyer of things.
+ *
+ * Tracks destructible objects and destroys them all when it itself is destroyed.
+ */
+export class Destroyer implements Destructible {
+  private readonly destructibles: Destructible[] = [];
+
+  add<T extends Destructible>(destructible: T): T {
+    this.destructibles.push(destructible);
+    return destructible;
+  }
+
+  destroy(): void {
+    let destructible: Destructible | undefined;
+    while ((destructible = this.destructibles.pop())) {
+      try {
+        destructible.destroy();
+      } catch (error) {
+        console.error("Failed to destroy object", destructible, error);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a Destroyer object to track a list of objects to be destroyed.

Then remove all this fields and instead use closures and local functions
to wire things up; this helps maintain proper initialization error
because Typescript errors for use before define, but only within the
same scope. It can't track use before define errors which occur in
methods invoked during initialization.
