### PR TITLE
Be more lenient with pnpm version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          # Keep in sync with engines.pnpm in package.json
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: latest
@@ -22,6 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          # Keep in sync with engines.pnpm in package.json
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: latest

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "lint": "eslint .",
     "format": "prettier ."
   },
+  "engines": {
+    "node": ">=20",
+    "pnpm": "^9"
+  },
   "devDependencies": {
     "@eslint/js": "^9.4.0",
     "@girs/gjs": "^3.3.0",
@@ -20,6 +24,5 @@
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.11.0"
-  },
-  "packageManager": "pnpm@9.1.1"
+  }
 }


### PR DESCRIPTION
Do not specify the package manager version for corepack; instead just
restrict the pnpm version with engines.pnpm.

This allows using a system-wide pnpm installation from the package
manager.