### PR TITLE
Update to GNOME Shell 46.0.2 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
-    "@girs/gjs": "^3.3.0",
-    "@girs/gnome-shell": "^46.0.0-beta6",
-    "@girs/soup-3.0": "^3.4.4-3.3.0",
+    "@girs/gjs": "4.0.0-beta.14",
+    "@girs/gnome-shell": "46.0.2",
+    "@girs/soup-3.0": "^3.4.4-4.0.0-beta.14",
     "@tsconfig/strictest": "^2.0.5",
     "eslint": "^9.9.1",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^9.9.1
         version: 9.9.1
       '@girs/gjs':
-        specifier: ^3.3.0
-        version: 3.3.0
+        specifier: 4.0.0-beta.14
+        version: 4.0.0-beta.14
       '@girs/gnome-shell':
-        specifier: ^46.0.0-beta6
-        version: 46.0.0-beta6
+        specifier: 46.0.2
+        version: 46.0.2
       '@girs/soup-3.0':
-        specifier: ^3.4.4-3.3.0
-        version: 3.4.4-3.3.0
+        specifier: ^3.4.4-4.0.0-beta.14
+        version: 3.4.4-4.0.0-beta.14
       '@tsconfig/strictest':
         specifier: ^2.0.5
         version: 2.0.5
@@ -74,140 +74,140 @@ packages:
     resolution: {integrity: sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@girs/accountsservice-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-CS3Nu/8dvPUGadf2eHFtDcZTunYD2lxA0NSpmOeIHR60g23fyJK24HX3KRkbPaO8Z7g6XDi5wlV3GnOH1qNoww==}
+  '@girs/accountsservice-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-SSmkaueQXF7O82aOJJu/XSmWy9dsO/YhcG7PmZNHbLXzLG1p7g7mpLLEHpeijijDQi2IzUdAvD+nAmHtNBNpug==}
 
-  '@girs/adw-1@1.4.3-3.3.0':
-    resolution: {integrity: sha512-BZBGnR+NjDyO4bUvY9WgWw2laFwVjNEye53NbyP/OyKgLViJmRd9eNdfb5743zLtjAvs3eB+5XIp1A5L0F9vqA==}
+  '@girs/adw-1@1.6.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-lKjlyM+xq3GGOHpMxSJ0b2gAzcZO9e1ZeFK6lV0TVPqWiu0i2EeC1Irld/yPFPb40m8Fl7pHJ52m2cpBeO12TA==}
 
-  '@girs/atk-1.0@2.50.1-3.3.0':
-    resolution: {integrity: sha512-D/25tpR8cezt6DXjAHJgKRylv8LCU7wwErmxoULVbTMyLACyJmhfPVo+bht2z68NQskyKK+5Np/fl2ZM/lRU4A==}
+  '@girs/atk-1.0@2.52.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-fiNoE2X41qPpWryBSztjh7dHbCgEzJuK7Or5lD4ZW1iojwf48FNdmcIwMqECzvzKm78RbIw6YWql+OXqdp1enA==}
 
-  '@girs/cairo-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-T879xrAa+V4T+uphu1niSnF2KTMMB+OSE5iH3iJbH8vq+HZJfo5YB1Kih6KWYByVLcqs+S/zLpK3Q/R5Ut4XaA==}
+  '@girs/cairo-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-WCk/3h3Opsh4xyOe/mNw7VGgJQsD7q54IK3e0W9C/INLp6A98gqe6ooA2AAWTmtLGwUjW0vMNOUBVb3A/sEIiA==}
 
-  '@girs/cally-14@14.0.0-3.3.0':
-    resolution: {integrity: sha512-vghsJqRyx7yg1NAkFo83bQKWKrhUJ1p+Nbg47B6Y2P1LYOucaoXtgD3z7JU/q2pbG04RuJYPITesUM8q4vCQsg==}
+  '@girs/cally-14@14.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-6WI5W3O+w2+XfcY4v91pWksSG9uXURS+Os4LPnGgZtVKuGWft75cAxM2FvR/YlWbk4Yad+Ewt7L6s+SjrQ975w==}
 
-  '@girs/clutter-14@14.0.0-3.3.0':
-    resolution: {integrity: sha512-bSm8OF3Tkiz2wzRnW0odvsOClaP1fDy94G1wd2kbg7FuWfoxK/rzpmwThIy0kW2V4Tmlg+4X0G8fe/m2Fs1Jhw==}
+  '@girs/clutter-14@14.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-xz1ej0iwjfMN09LTdBlWIRpHSs2KF3ZyC5bszwlf1VCnffB7tUvKWoy0hyM5jMrSvAC0vctJOLr9hLFfjPyvQg==}
 
-  '@girs/cogl-14@14.0.0-3.3.0':
-    resolution: {integrity: sha512-YnBk/f8VcK/UtBYbc1A45DFqHM/imTMU4BPI+sP6bg8z1qpyyfHPKTCaO9WALXUQd/tNCQ3ckm2Lapol3w/s0Q==}
+  '@girs/cogl-14@14.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-cfsT9G4q3zND9Zpfl95R/NZ9nKVGrU3H0WAByloH08EKI5oJLdVJvmoJ2k+ZMMn8/kYSSg5pAcXuJOSw6uyP5g==}
 
-  '@girs/cogl-2.0@2.0.0-3.3.0':
-    resolution: {integrity: sha512-3C/Gr4yo6Oz/bF9MzQn73kHdmAfYJkqyhfcbXIAFAwsvng3C3DArLXkQK7PiR2/jvDY0tm9z+OusV5V3L17WRg==}
+  '@girs/cogl-2.0@2.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-A/xV/PuwtllnpoSDidG97y/poTd45Eplocc/IDyuiyzSvPK1RPHThx9AWKqk69i7FdG0jQzF7GAn8ZICbCVx8A==}
 
-  '@girs/coglpango-14@14.0.0-3.3.0':
-    resolution: {integrity: sha512-xFJL4qMVnQIgKD04dv31ctpXGDEOKJWMW0zfuSn4UVx4aS99R0xZv1VAjrut7ueYglVDpTZc99NqUsaneTnypA==}
+  '@girs/coglpango-14@14.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-i0Am8I1JO0V73iPF/HYoQSavBAfEUJd/e3LIhxvp74USckYHjt5JaJcxNBLc2VKZFPkuxP+2YfcWUS49s7lrsg==}
 
-  '@girs/freetype2-2.0@2.0.0-3.3.0':
-    resolution: {integrity: sha512-kysYooLkRbHVIYnQxzljaakt9R/daRG3Po704+0jH6X8W/JBxiWOaHNglNFYC7wfynYTwxnGmOG/5oXLSdS64g==}
+  '@girs/freetype2-2.0@2.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-imJOTeCG8rVzKwcc6ISMfkfjsZ4zsB60Za4OZj3aLAxkRVHIf95ToPGZFm2IFW4s2aKNFMP5WGI8/0ezonUhEw==}
 
-  '@girs/gck-2@4.1.0-3.3.0':
-    resolution: {integrity: sha512-SD7PRY6c1kpAN/K+chGbxck9KfeV2s7DgGwu4RXhfxmwRIDtsn4fwgaihafj/9rDFsOpXHMqRbdPCUNyxCgnIA==}
+  '@girs/gck-2@4.3.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-F2cRdA3QSrU4fpkzB7Aj5UYsloy/gIMfnd/Sj04SR5IMzCeOhKXa28amcvuTWdHfNG9G4jwU8PB/ue3zGxLnPw==}
 
-  '@girs/gcr-4@4.1.0-3.3.0':
-    resolution: {integrity: sha512-F5x1EJ5/UqXra7mdYtaK8VbQRzvk1PjJJb/FUbY5+rSzDr/kwmDqC7TSo/mIeYe4Lvtg3rd5PPPh/AQHHgtp2A==}
+  '@girs/gcr-4@4.3.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-yk+YGv9rpbRkmSPXHpRT06HQ78bsVj92c6PtJ/ZKOHez2Tj6ZyilWryGXZpL28TxUYdleBqYp65Zs+IauSx6sg==}
 
-  '@girs/gdesktopenums-3.0@3.0.0-3.3.0':
-    resolution: {integrity: sha512-mW/vjWySL98cqq9UK/NXtjrjhWIbSg7A4xzWM+Xw5fHoPVs6JsDfzq6/zahSmMdkdqMZ7dFxL9ahphhme3Ye7w==}
+  '@girs/gdesktopenums-3.0@3.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-oHvN+XhEfcwd4NM16K2tczdH+M5IFKRzzKFhOKQ+UvyYpyxRkMIJhhsYn5IkOWyTT6mYwwFgoiDldW6Ub3mFdg==}
 
-  '@girs/gdk-4.0@4.0.0-3.3.0':
-    resolution: {integrity: sha512-ExHbUi+oVVBJnEfwzqq1QODEXKGX+cieCyqgiuseCdHJZjU13RhPbPWLNINkcxGfDDjTZrwHaUaAoe6oJkgxFw==}
+  '@girs/gdk-4.0@4.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-0UHud/CkxmKB1iPrXCt35ukB48LX7ND071B2A5N2VA9sgxxljHdDeQPsxNKT+rt+uLEbMdVCB7qBRfrNglfvzA==}
 
-  '@girs/gdkpixbuf-2.0@2.0.0-3.3.0':
-    resolution: {integrity: sha512-hdgb16YgkT70h9A7243XatjL6kooLoJ8VT0rPwC/tjE8MXcG4mpcC1RliRLrASPozUcB2pDuM17VsTSBUJYBcg==}
+  '@girs/gdkpixbuf-2.0@2.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-Dj00URSTB3jp+mvvrt5iCSCDzWKdi8/3/P8hbkSf8/Zp3clO9l7NdPCxEvl1YGwCqwQKNY7M9xcVYcmL8hnbPQ==}
 
-  '@girs/gdm-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-C8VI2xauCiIVRDhB0tR2AJszxdqHG6tWkxiecoyE9982sTbjQbhIlDo67apfJ9zvJUWe0FDjy0D++9/NuNLKWA==}
+  '@girs/gdm-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-CrBNkqBkZ+eRihfWF2IcZygcreEGdnvg9G94Imod30GYaPVi9vPHDFzrpGMDn2B14OO1AYwd1TmrqmrmTL3wMQ==}
 
-  '@girs/gio-2.0@2.78.0-3.3.0':
-    resolution: {integrity: sha512-39VvlB9Mzikh39cR80VMbsNxW4TG9axCKQwzAtEEwaSmvj6PzOo7KpGQ4/prRH98F1mAKQ1muLWz4H3A+zz3NA==}
+  '@girs/gio-2.0@2.80.3-4.0.0-beta.14':
+    resolution: {integrity: sha512-ZPcUYDJOTf1z1xN0nGGZEgUzAGl6ZxTeJFH5nTaILmnYpnHR50EG+5YzGi+PUwQzuafMYj6KkHXh9HW4723ctw==}
 
-  '@girs/gjs@3.3.0':
-    resolution: {integrity: sha512-5cQaouORn53vLM+cFAEOzJuzcm47eH86R2OGUgrHIL4KT7sEm+BKkhqlI67m+iJUMl/I72P2Hfe+Am4jl0YxlQ==}
+  '@girs/gjs@4.0.0-beta.14':
+    resolution: {integrity: sha512-80uV5SGGN7JxXWV3BRlJRSQ2eoOYZvJqJ5/507XXMhGBMOnxv4PIZcmTYNsEBqpWSr8n9mtCuNFxdRuikbpnUg==}
 
-  '@girs/gl-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-3V91WV1o+3VtXzGQHveCGVZPgHzI6NwDq4ZEqOBj8jDSzQw3LWD4Z5ZEFsNqF8MWD8DE+mXdTMN1u1pfkME5zQ==}
+  '@girs/gl-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-kXDpDZ3n2QBWlz2YY3UqDUhVCKO/n9ARBEPCLSJerTY0fsypfkbMgSNX+Unytahmmdmyz6DGmObkiyCG6YraVQ==}
 
-  '@girs/glib-2.0@2.78.0-3.3.0':
-    resolution: {integrity: sha512-XuoKuOm9aNVou+yWtlbcwEcNI7v1gCJUBQboPlZxft+o9CnP2FmwRntqZnfhZepGmLbASMA8Ow5iEL8glNwVsw==}
+  '@girs/glib-2.0@2.80.3-4.0.0-beta.14':
+    resolution: {integrity: sha512-RCXtrsYjRXhPHfT0DVAG5T2ns+KjyJzpNxhECyr1C1nGq6tCnyGHrtIJ8NrVOA19yDKs7HVKRE1rROBrLglRDw==}
 
-  '@girs/gmodule-2.0@2.0.0-3.3.0':
-    resolution: {integrity: sha512-laYKNuio+V14PwjYZZ2K86BpotIf9IlnGJwsaS9iHHjLPCTY3Uq38DTV2ahnyTY7C9K25JT25UFXh2hPfYudqw==}
+  '@girs/gmodule-2.0@2.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-0V/KhUK92rsGcYaxXMVDsx82x8U/E+t5G2NiaqmTreMPaJhAnaYgFTJg1KsZpTGJKH1mvnLusbW0apQcAxcB5Q==}
 
-  '@girs/gnome-shell@46.0.0-beta6':
-    resolution: {integrity: sha512-ZDTtXDueIfYfkvQP4xjVcr809eeLGcJfmRAe4taY9KEfrMe/Ha79gTLFpkIKN/zecIft7Gb6emXSfBTWyfBrlA==}
+  '@girs/gnome-shell@46.0.2':
+    resolution: {integrity: sha512-3200N6FZstRaDndKm2lDZ7ZeeutJoa+dm8pqU1J6a7PYL0H+JGZIDtarcBWCfMBnIvcFeT7y8vgdooe8X3y3KA==}
 
-  '@girs/gnomebg-4.0@4.0.0-3.3.0':
-    resolution: {integrity: sha512-l0LuE4WC1+ss7YClCHXwaoOPRWVr1OmO1ZZmY4WrX/jFgdeTPD5xYAK+7e2eXXr/7d2TQtEEQXX1iCITRS0OWQ==}
+  '@girs/gnomebg-4.0@4.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-jAfYgliYAn9PrJAu7D4Wrzqcfn3PQw1mjko+6U9potu5IpoU3eAhJ5MSWucql4kstO4JeoBF2zmw2iXIRE5nyw==}
 
-  '@girs/gnomebluetooth-3.0@3.0.0-3.3.0':
-    resolution: {integrity: sha512-FqSYzaifvBqBDgidPeumCFb+A4obI2W+6vJ15sCYk6Ck2a0OUMz6CTuSr08PK6BhE1MFNPEmTqkwIL8Hs4BJww==}
+  '@girs/gnomebluetooth-3.0@3.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-GRObEwmIrsW9buGwfKvkUjEIrx4Ca5gOQjAgCQKkOExVOJcqqkpbi+VyuaCadfG9LhmJFj0a/tELH722Fhm+9Q==}
 
-  '@girs/gnomedesktop-4.0@4.0.0-3.3.0':
-    resolution: {integrity: sha512-s0HC4IZzXURil9Mn9A+lY1tcJv0jKr78cjflvjAWEtRkSYZI8hrs3ZuAf59CpvaUTXXhLPr7+unH5pRgi7Xp/Q==}
+  '@girs/gnomedesktop-4.0@4.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-cQBgic3iPlZ0T2fbSfeKmIfvp5/kbvkmgqc4RJ9k45OVHVRtSL+4ccePGDqV6PBu06mXzJ1PJQUacCQ43S0c/w==}
 
-  '@girs/gobject-2.0@2.78.0-3.3.0':
-    resolution: {integrity: sha512-s6IpE1o9uAf8kZgncWjdYerErhWXgszIFHXEvvyKR8csI36SFD730CqJRiCepP2okoJmD0Vi3jrnuq5jb8wIMA==}
+  '@girs/gobject-2.0@2.80.3-4.0.0-beta.14':
+    resolution: {integrity: sha512-2yJcCmf0vGG1hHI286C6opegSO03fPeg4t3pRbc2fl3u5cx+lLKRvbA85ZzL8qpFicxRLrkWjaQEWcV8y+3zfA==}
 
-  '@girs/graphene-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-cXQ5wGaoVx52dDwPnhb4nfgX3MEvN8uKX8yABLYlD9JyvtkCyZ48DV8l/G3MuHWT+vbwp7uLPA46XV7ABbiuhA==}
+  '@girs/graphene-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-+M7qa9ZiHK1kHxKUhygbPK+bxLkTyQbK0glUVp3vTmcY4BMngjheQsqxC/U5+um6fRZNIa6Yo0+0j8l5QDG2aw==}
 
-  '@girs/gsk-4.0@4.0.0-3.3.0':
-    resolution: {integrity: sha512-B7XWkYpRE84KdGAZ+d07mi76tAinFKAzDivb0DwYEWri6afmbCNh/ZqRyRoMd7eZAgGufDEGKGGU1g1ryrvS4w==}
+  '@girs/gsk-4.0@4.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-CqtsrrOcHwZ5hVS70ZbXk8r4wh8qA4W74u0RiwkRho2bjjpWVH1bw3f3AjJaj6a0FIig+p9B7765tVYp4LCH4w==}
 
-  '@girs/gtk-4.0@4.12.5-3.3.0':
-    resolution: {integrity: sha512-J7F54w6GhYWOmV05l/gDWg8L16JUmQtVgmhVrlM0oMiRBR9hs75rPVsTFx5VslwcJ3chxFBwJrQeK79TYwLprA==}
+  '@girs/gtk-4.0@4.14.4-4.0.0-beta.14':
+    resolution: {integrity: sha512-5mUEWq7PBuxfGL//VEgRY2+1OwUm6ll6qW1yJ55skfVJWEyQo6TfGRhbortxtSgCx0yvZh3c0XLbgjYxuZ4SgQ==}
 
-  '@girs/gvc-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-ub/pm6D7+EpL9KUHj+QICs1kASfUICWrMvV9qsDqz0VXcgFwx3/gpC2pc/BU4knjqCyAA8hqCIIma0A3I7eeiA==}
+  '@girs/gvc-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-4JGjLH4uekONzrpmnpIB6xNK3miBKRF1YR0f3do2/4Wioltdj4g2Depk+sg4IJh24SVItiXQO8+0mPb8kU0TNA==}
 
-  '@girs/harfbuzz-0.0@8.2.1-3.3.0':
-    resolution: {integrity: sha512-3KxPdBMNR2IDmJaEZEZ7DBw4gF0eylIJ57ZKOWRfGsSWauUhIHkNYRY7Ig8dL3kF62certdFZpaVXO44likjzQ==}
+  '@girs/harfbuzz-0.0@8.5.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-bhtJzf63O69wJ41FhkjzbCWbt2Ilzxdi9vOyWrGPX3u9Mr+c1pKlH/+rUuC8Ey0MUHWJT9DoUSrtXflYjplsGA==}
 
-  '@girs/meta-14@14.0.0-3.3.0':
-    resolution: {integrity: sha512-wQu3Dw4p22PujIfipPM/Cwq4iLC+3NmcnX+pwiJ1bgQPU7fCUfy3poRWBOgqGLOojAqSC1kI2noY8w7oA8m2qg==}
+  '@girs/meta-14@14.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-Kl4c3JYh9h4M9sq0Q5PXOHM3FTEQDDSZ3VGQ+21cHjAs9WV2MCJmW3fMJY/rcYOvuKA9jhF5IVx9zwhaaHDZcg==}
 
-  '@girs/mtk-14@14.0.0-3.3.0':
-    resolution: {integrity: sha512-6q03QCwHVDotn5AmpTEscgNWUytgeS3fbwPNsm2Ded9y6eaDu8HPjirKp2gSE5+11S8ZrvKBvxnjUqre3B3Ddg==}
+  '@girs/mtk-14@14.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-+NlXzUDfsR+uiVeHC/y8+uq419+p27z1FP7bdFgV9aezEMeStqVMY+ekceS6v1njFJC/T5MYtDLBnTUX4VD/nw==}
 
-  '@girs/nm-1.0@1.45.1-3.3.0':
-    resolution: {integrity: sha512-ebVtkiVzjxFNpzGv5IJHQmtObRIg8R5s49b4DGdLe1xI12FtWwMKmtF6PxsqHS+YMNaGZRZXsZLn0PrvukmOag==}
+  '@girs/nm-1.0@1.46.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-FLxpmqaQwaPx9MOup2zqS8bgwz7CqN2klBliZ4LqmXbd38ZXQmqcLzdBso0Km6jY3qAEEiCeFGt5PY2TAFcRmA==}
 
-  '@girs/pango-1.0@1.51.0-3.3.0':
-    resolution: {integrity: sha512-4Y7NOi2jE0MIiVv+ljYbGbG+wvQ6lQ08nD0UTy2Y1PQwro8wfZgS3JMDD9bZ00gq2hpTKqpPApCjFCE/ZYgzZQ==}
+  '@girs/pango-1.0@1.54.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-LVslEEjzvZRbiuLB2uUqQJUV4kxh9/+KkkB1KZnh1hWQ6yBtG+36086PTxMhOV823yAJI8ZsBFu9gjEv8t3UJw==}
 
-  '@girs/pangocairo-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-xufD30YWR2dSUznmNto3Ud87D9oWEwgY/RMUVz0iz2ADjbDXLlHym5MJ7MorOzcUAhn1q3iieidqVIkEmqB9Ng==}
+  '@girs/pangocairo-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-LhW5AT/yy8U85CaDcGxP7n33FY5SlaXVXnolOP8LpBq+mH/1Mcvmv3PDEIJnV6s5ZCbMf2eUXube/MACEnzdGg==}
 
-  '@girs/polkit-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-zuJmeZihENr8sIQTysNMZZYoRSIR1Jk6v0zP/S6fvCG9kThDTCQliNO2Mx89XvQtRYBK+yx9DxYgkxYbs+qeaw==}
+  '@girs/polkit-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-kbZgtd4j1t1J97+6y54JIvwe++Th3JlKfvH6lDea29aJcltceHocTgKLNs0dDrarRmNEloI8cRvVKgHf1ycV/g==}
 
-  '@girs/polkitagent-1.0@1.0.0-3.3.0':
-    resolution: {integrity: sha512-qarn/Lg+5j4Tadngi2uZe137olzYQLI3Wj1Bjzsv/+M6k26uCo0Ekwl1TR6FJfmQp9S1ICr/0PM7IWv98egL4w==}
+  '@girs/polkitagent-1.0@1.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-G8zGxv8FmdeuPlnkzeqjycIDD2ORcsNYTqxRibCWJVUtzUYy+cxzW26uWKvF1fi5PIGoffIPfkguhFog/ra16A==}
 
-  '@girs/shell-14@14.0.0-3.3.0':
-    resolution: {integrity: sha512-qMP5Wsk+yzSkA9KADWU5g0NTFFpgRELkwLys1A8TzdVPzpHdjS6EDdixV6amgl+qnuXh8q2bzuGWXUfAQXPyBQ==}
+  '@girs/shell-14@14.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-X07pTusZ0j03HibbOwKDGpv8l9gH5u82NpTrK/vPtz7eQACAc4C0Rf1w/22JqN/kFWLR/QenyiJs/mmMx6UkyA==}
 
-  '@girs/shew-0@0.0.0-3.3.0':
-    resolution: {integrity: sha512-/BHVcuHC4kAqp2iN6rFRAr5AtoxNkV5neFxqSH8/24DZSHZyJ47uYvGMb0xIx3xpAm4jcdT2ZCG9plJLeCCx6g==}
+  '@girs/shew-0@0.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-YkWmmx9OTh1FIYLg9TBGudFMz1uNCe7dE+mRJtZ+LRNYQZvWAdUMlN8JGSKrB5tb4ahOvg+GdB8RBtDaJDDFMQ==}
 
-  '@girs/soup-3.0@3.4.4-3.3.0':
-    resolution: {integrity: sha512-KDICwH2Cn097eUdphyetVqSGbj60yui2zfiJDuRjBU2MKnIQUelmrcMSZbFA7K0EUUg3i5i9bRN9j9bGTj/XLw==}
+  '@girs/soup-3.0@3.4.4-4.0.0-beta.14':
+    resolution: {integrity: sha512-KwUblP7bscObScLevGAApUz5YnoUNsaBSk1Jr7gQ6W936wlIAfSH+vnqqbNe1Vxla1Bw/Teudj2QRRcgAzof2A==}
 
-  '@girs/st-14@14.0.0-3.3.0':
-    resolution: {integrity: sha512-gnvl7lNBWSd4g0U6ejTUGPmwY9l4WGXdG452FmNArOAnHLuOpjf3M0ncNdkytmYd8eL70k+VrftwGrEhacXizQ==}
+  '@girs/st-14@14.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-FP0vKqdGU4bJcVgoXHvd141Lhv7Y3/wJvzCWGRl4vsqfv4mYZ4rRtxjfyVOGAsnUBjfsh49c7roAJ7T07TuQfA==}
 
-  '@girs/upowerglib-1.0@0.99.1-3.3.0':
-    resolution: {integrity: sha512-kRx+yyhjs3egM8jQG4FjsNuFiOLw5kWqUFlWHuforTTaaLGqcj/iLHjIHwWqlCOxrqCSMtU7ZrIYlhmAoPgCjQ==}
+  '@girs/upowerglib-1.0@0.99.1-4.0.0-beta.14':
+    resolution: {integrity: sha512-xknV5KnSc4sR/J7roYxSdHVL7hU/AKywEHfi8CwV11HHYcx5XLai5UUyOFZW/BluNr6x6zgajggGAgfNW+I91w==}
 
-  '@girs/xfixes-4.0@4.0.0-3.3.0':
-    resolution: {integrity: sha512-Ld3Xi0QmigVJ83sTecQLSvqN28SemrA2Ja2LlPATWKIkT/S4emYl9bNfhXvYmay3JKykA+wAlFAwZKhADXGTeQ==}
+  '@girs/xfixes-4.0@4.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-vBaDNSCi0yVhpBY1g6ybINWuwPU4r1vuzCimAFwwL+m2NaXqfLfP4Mg20INx51r5pAsIv555GMDdsSYB+0GaRw==}
 
-  '@girs/xlib-2.0@2.0.0-3.3.0':
-    resolution: {integrity: sha512-OkU9DX8ojRWBq70Dw+z4GfP0yT/m0kKkU1ZxPDkTORwMQYMf7AuXHF3Kn2mJeeHhQUuj6nXWyzXnd9q7jHhvAg==}
+  '@girs/xlib-2.0@2.0.0-4.0.0-beta.14':
+    resolution: {integrity: sha512-K3IqM3UdbqcLukMzFVvHUkHtJseEqxTZQ0pRcj9K3upq3T4ZhzHgS8Y8s5qPUUK7arkdpM72IU/j9I9mtjmJKg==}
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -718,488 +718,508 @@ snapshots:
 
   '@eslint/object-schema@2.1.4': {}
 
-  '@girs/accountsservice-1.0@1.0.0-3.3.0':
+  '@girs/accountsservice-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/adw-1@1.4.3-3.3.0':
+  '@girs/adw-1@1.6.0-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gdk-4.0': 4.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/gsk-4.0': 4.0.0-3.3.0
-      '@girs/gtk-4.0': 4.12.5-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/gsk-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gtk-4.0': 4.14.4-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
 
-  '@girs/atk-1.0@2.50.1-3.3.0':
+  '@girs/atk-1.0@2.52.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/cairo-1.0@1.0.0-3.3.0':
+  '@girs/cairo-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/cally-14@14.0.0-3.3.0':
+  '@girs/cally-14@14.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/atk-1.0': 2.50.1-3.3.0
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/clutter-14': 14.0.0-3.3.0
-      '@girs/cogl-14': 14.0.0-3.3.0
-      '@girs/coglpango-14': 14.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/gl-1.0': 1.0.0-3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/mtk-14': 14.0.0-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
-      '@girs/xlib-2.0': 2.0.0-3.3.0
+      '@girs/atk-1.0': 2.52.0-4.0.0-beta.14
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/clutter-14': 14.0.0-4.0.0-beta.14
+      '@girs/cogl-14': 14.0.0-4.0.0-beta.14
+      '@girs/coglpango-14': 14.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/mtk-14': 14.0.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.14
 
-  '@girs/clutter-14@14.0.0-3.3.0':
+  '@girs/clutter-14@14.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/atk-1.0': 2.50.1-3.3.0
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/cogl-14': 14.0.0-3.3.0
-      '@girs/coglpango-14': 14.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/gl-1.0': 1.0.0-3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/mtk-14': 14.0.0-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
-      '@girs/xlib-2.0': 2.0.0-3.3.0
+      '@girs/atk-1.0': 2.52.0-4.0.0-beta.14
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/cogl-14': 14.0.0-4.0.0-beta.14
+      '@girs/coglpango-14': 14.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/mtk-14': 14.0.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.14
 
-  '@girs/cogl-14@14.0.0-3.3.0':
+  '@girs/cogl-14@14.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/gl-1.0': 1.0.0-3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/mtk-14': 14.0.0-3.3.0
-      '@girs/xlib-2.0': 2.0.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/mtk-14': 14.0.0-4.0.0-beta.14
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.14
 
-  '@girs/cogl-2.0@2.0.0-3.3.0':
+  '@girs/cogl-2.0@2.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/gl-1.0': 1.0.0-3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/coglpango-14@14.0.0-3.3.0':
+  '@girs/coglpango-14@14.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/cogl-14': 14.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/gl-1.0': 1.0.0-3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/mtk-14': 14.0.0-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
-      '@girs/xlib-2.0': 2.0.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/cogl-14': 14.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/mtk-14': 14.0.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.14
 
-  '@girs/freetype2-2.0@2.0.0-3.3.0':
+  '@girs/freetype2-2.0@2.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gck-2@4.1.0-3.3.0':
+  '@girs/gck-2@4.3.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gcr-4@4.1.0-3.3.0':
+  '@girs/gcr-4@4.3.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gck-2': 4.1.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gck-2': 4.3.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gdesktopenums-3.0@3.0.0-3.3.0':
+  '@girs/gdesktopenums-3.0@3.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gdk-4.0@4.0.0-3.3.0':
+  '@girs/gdk-4.0@4.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
 
-  '@girs/gdkpixbuf-2.0@2.0.0-3.3.0':
+  '@girs/gdkpixbuf-2.0@2.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gdm-1.0@1.0.0-3.3.0':
+  '@girs/gdm-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gio-2.0@2.78.0-3.3.0':
+  '@girs/gio-2.0@2.80.3-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gjs@3.3.0':
+  '@girs/gjs@4.0.0-beta.14':
     dependencies:
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gl-1.0@1.0.0-3.3.0':
+  '@girs/gl-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/glib-2.0@2.78.0-3.3.0':
+  '@girs/glib-2.0@2.80.3-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gmodule-2.0@2.0.0-3.3.0':
+  '@girs/gmodule-2.0@2.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gnome-shell@46.0.0-beta6':
+  '@girs/gnome-shell@46.0.2':
     dependencies:
-      '@girs/accountsservice-1.0': 1.0.0-3.3.0
-      '@girs/adw-1': 1.4.3-3.3.0
-      '@girs/atk-1.0': 2.50.1-3.3.0
-      '@girs/cally-14': 14.0.0-3.3.0
-      '@girs/clutter-14': 14.0.0-3.3.0
-      '@girs/cogl-2.0': 2.0.0-3.3.0
-      '@girs/gcr-4': 4.1.0-3.3.0
-      '@girs/gdm-1.0': 1.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gnomebg-4.0': 4.0.0-3.3.0
-      '@girs/gnomebluetooth-3.0': 3.0.0-3.3.0
-      '@girs/gnomedesktop-4.0': 4.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/gtk-4.0': 4.12.5-3.3.0
-      '@girs/gvc-1.0': 1.0.0-3.3.0
-      '@girs/meta-14': 14.0.0-3.3.0
-      '@girs/mtk-14': 14.0.0-3.3.0
-      '@girs/polkit-1.0': 1.0.0-3.3.0
-      '@girs/shell-14': 14.0.0-3.3.0
-      '@girs/shew-0': 0.0.0-3.3.0
-      '@girs/st-14': 14.0.0-3.3.0
-      '@girs/upowerglib-1.0': 0.99.1-3.3.0
+      '@girs/accountsservice-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/adw-1': 1.6.0-4.0.0-beta.14
+      '@girs/atk-1.0': 2.52.0-4.0.0-beta.14
+      '@girs/cally-14': 14.0.0-4.0.0-beta.14
+      '@girs/clutter-14': 14.0.0-4.0.0-beta.14
+      '@girs/cogl-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gcr-4': 4.3.0-4.0.0-beta.14
+      '@girs/gdm-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gnomebg-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gnomebluetooth-3.0': 3.0.0-4.0.0-beta.14
+      '@girs/gnomedesktop-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gtk-4.0': 4.14.4-4.0.0-beta.14
+      '@girs/gvc-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/meta-14': 14.0.0-4.0.0-beta.14
+      '@girs/mtk-14': 14.0.0-4.0.0-beta.14
+      '@girs/polkit-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/shell-14': 14.0.0-4.0.0-beta.14
+      '@girs/shew-0': 0.0.0-4.0.0-beta.14
+      '@girs/st-14': 14.0.0-4.0.0-beta.14
+      '@girs/upowerglib-1.0': 0.99.1-4.0.0-beta.14
 
-  '@girs/gnomebg-4.0@4.0.0-3.3.0':
+  '@girs/gnomebg-4.0@4.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gdesktopenums-3.0': 3.0.0-3.3.0
-      '@girs/gdk-4.0': 4.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gnomedesktop-4.0': 4.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.14
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gnomedesktop-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
 
-  '@girs/gnomebluetooth-3.0@3.0.0-3.3.0':
+  '@girs/gnomebluetooth-3.0@3.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gnomedesktop-4.0@4.0.0-3.3.0':
+  '@girs/gnomedesktop-4.0@4.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gdesktopenums-3.0': 3.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gobject-2.0@2.78.0-3.3.0':
+  '@girs/gobject-2.0@2.80.3-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/graphene-1.0@1.0.0-3.3.0':
+  '@girs/graphene-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/gsk-4.0@4.0.0-3.3.0':
+  '@girs/gsk-4.0@4.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gdk-4.0': 4.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
 
-  '@girs/gtk-4.0@4.12.5-3.3.0':
+  '@girs/gtk-4.0@4.14.4-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gdk-4.0': 4.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/gsk-4.0': 4.0.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/gsk-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
 
-  '@girs/gvc-1.0@1.0.0-3.3.0':
+  '@girs/gvc-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/harfbuzz-0.0@8.2.1-3.3.0':
+  '@girs/harfbuzz-0.0@8.5.0-4.0.0-beta.14':
     dependencies:
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/meta-14@14.0.0-3.3.0':
+  '@girs/meta-14@14.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/atk-1.0': 2.50.1-3.3.0
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/clutter-14': 14.0.0-3.3.0
-      '@girs/cogl-14': 14.0.0-3.3.0
-      '@girs/coglpango-14': 14.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gdesktopenums-3.0': 3.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/gl-1.0': 1.0.0-3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/mtk-14': 14.0.0-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
-      '@girs/xfixes-4.0': 4.0.0-3.3.0
-      '@girs/xlib-2.0': 2.0.0-3.3.0
+      '@girs/atk-1.0': 2.52.0-4.0.0-beta.14
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/clutter-14': 14.0.0-4.0.0-beta.14
+      '@girs/cogl-14': 14.0.0-4.0.0-beta.14
+      '@girs/coglpango-14': 14.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/mtk-14': 14.0.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/xfixes-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.14
 
-  '@girs/mtk-14@14.0.0-3.3.0':
+  '@girs/mtk-14@14.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
 
-  '@girs/nm-1.0@1.45.1-3.3.0':
+  '@girs/nm-1.0@1.46.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/pango-1.0@1.51.0-3.3.0':
+  '@girs/pango-1.0@1.54.0-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
 
-  '@girs/pangocairo-1.0@1.0.0-3.3.0':
+  '@girs/pangocairo-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
 
-  '@girs/polkit-1.0@1.0.0-3.3.0':
+  '@girs/polkit-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/polkitagent-1.0@1.0.0-3.3.0':
+  '@girs/polkitagent-1.0@1.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/polkit-1.0': 1.0.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/polkit-1.0': 1.0.0-4.0.0-beta.14
 
-  '@girs/shell-14@14.0.0-3.3.0':
+  '@girs/shell-14@14.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/atk-1.0': 2.50.1-3.3.0
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/cally-14': 14.0.0-3.3.0
-      '@girs/clutter-14': 14.0.0-3.3.0
-      '@girs/cogl-14': 14.0.0-3.3.0
-      '@girs/coglpango-14': 14.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gck-2': 4.1.0-3.3.0
-      '@girs/gcr-4': 4.1.0-3.3.0
-      '@girs/gdesktopenums-3.0': 3.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/gl-1.0': 1.0.0-3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/gvc-1.0': 1.0.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/meta-14': 14.0.0-3.3.0
-      '@girs/mtk-14': 14.0.0-3.3.0
-      '@girs/nm-1.0': 1.45.1-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
-      '@girs/polkit-1.0': 1.0.0-3.3.0
-      '@girs/polkitagent-1.0': 1.0.0-3.3.0
-      '@girs/st-14': 14.0.0-3.3.0
-      '@girs/xfixes-4.0': 4.0.0-3.3.0
-      '@girs/xlib-2.0': 2.0.0-3.3.0
+      '@girs/atk-1.0': 2.52.0-4.0.0-beta.14
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/cally-14': 14.0.0-4.0.0-beta.14
+      '@girs/clutter-14': 14.0.0-4.0.0-beta.14
+      '@girs/cogl-14': 14.0.0-4.0.0-beta.14
+      '@girs/coglpango-14': 14.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gck-2': 4.3.0-4.0.0-beta.14
+      '@girs/gcr-4': 4.3.0-4.0.0-beta.14
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/gvc-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/meta-14': 14.0.0-4.0.0-beta.14
+      '@girs/mtk-14': 14.0.0-4.0.0-beta.14
+      '@girs/nm-1.0': 1.46.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/polkit-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/polkitagent-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/st-14': 14.0.0-4.0.0-beta.14
+      '@girs/xfixes-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.14
 
-  '@girs/shew-0@0.0.0-3.3.0':
+  '@girs/shew-0@0.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gdk-4.0': 4.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/gsk-4.0': 4.0.0-3.3.0
-      '@girs/gtk-4.0': 4.12.5-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gdk-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/gsk-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/gtk-4.0': 4.14.4-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
 
-  '@girs/soup-3.0@3.4.4-3.3.0':
+  '@girs/soup-3.0@3.4.4-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/st-14@14.0.0-3.3.0':
+  '@girs/st-14@14.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/atk-1.0': 2.50.1-3.3.0
-      '@girs/cairo-1.0': 1.0.0-3.3.0
-      '@girs/cally-14': 14.0.0-3.3.0
-      '@girs/clutter-14': 14.0.0-3.3.0
-      '@girs/cogl-14': 14.0.0-3.3.0
-      '@girs/coglpango-14': 14.0.0-3.3.0
-      '@girs/freetype2-2.0': 2.0.0-3.3.0
-      '@girs/gdesktopenums-3.0': 3.0.0-3.3.0
-      '@girs/gdkpixbuf-2.0': 2.0.0-3.3.0
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/gl-1.0': 1.0.0-3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gmodule-2.0': 2.0.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
-      '@girs/graphene-1.0': 1.0.0-3.3.0
-      '@girs/harfbuzz-0.0': 8.2.1-3.3.0
-      '@girs/meta-14': 14.0.0-3.3.0
-      '@girs/mtk-14': 14.0.0-3.3.0
-      '@girs/pango-1.0': 1.51.0-3.3.0
-      '@girs/pangocairo-1.0': 1.0.0-3.3.0
-      '@girs/xfixes-4.0': 4.0.0-3.3.0
-      '@girs/xlib-2.0': 2.0.0-3.3.0
+      '@girs/atk-1.0': 2.52.0-4.0.0-beta.14
+      '@girs/cairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/cally-14': 14.0.0-4.0.0-beta.14
+      '@girs/clutter-14': 14.0.0-4.0.0-beta.14
+      '@girs/cogl-14': 14.0.0-4.0.0-beta.14
+      '@girs/coglpango-14': 14.0.0-4.0.0-beta.14
+      '@girs/freetype2-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gdesktopenums-3.0': 3.0.0-4.0.0-beta.14
+      '@girs/gdkpixbuf-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gl-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/graphene-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/harfbuzz-0.0': 8.5.0-4.0.0-beta.14
+      '@girs/meta-14': 14.0.0-4.0.0-beta.14
+      '@girs/mtk-14': 14.0.0-4.0.0-beta.14
+      '@girs/pango-1.0': 1.54.0-4.0.0-beta.14
+      '@girs/pangocairo-1.0': 1.0.0-4.0.0-beta.14
+      '@girs/xfixes-4.0': 4.0.0-4.0.0-beta.14
+      '@girs/xlib-2.0': 2.0.0-4.0.0-beta.14
 
-  '@girs/upowerglib-1.0@0.99.1-3.3.0':
+  '@girs/upowerglib-1.0@0.99.1-4.0.0-beta.14':
     dependencies:
-      '@girs/gio-2.0': 2.78.0-3.3.0
-      '@girs/gjs': 3.3.0
-      '@girs/glib-2.0': 2.78.0-3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gio-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/glib-2.0': 2.80.3-4.0.0-beta.14
+      '@girs/gmodule-2.0': 2.0.0-4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/xfixes-4.0@4.0.0-3.3.0':
+  '@girs/xfixes-4.0@4.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
-  '@girs/xlib-2.0@2.0.0-3.3.0':
+  '@girs/xlib-2.0@2.0.0-4.0.0-beta.14':
     dependencies:
-      '@girs/gjs': 3.3.0
-      '@girs/gobject-2.0': 2.78.0-3.3.0
+      '@girs/gjs': 4.0.0-beta.14
+      '@girs/gobject-2.0': 2.80.3-4.0.0-beta.14
 
   '@humanwhocodes/module-importer@1.0.1': {}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,9 +178,6 @@ const initializeExtension = (
 
   // Wire up the current source
   const currentSource = settings.get_string("selected-source");
-  if (currentSource === null) {
-    throw new Error("Current source 'null'?");
-  }
   const sourceSelector = destroyer.add(SourceSelector.forKey(currentSource));
   indicator.updateSelectedSource(sourceSelector.selectedSource.metadata);
   const sourceSettings = SourceSettings.fromBaseSettings(extension, settings);

--- a/src/lib/fixes.ts
+++ b/src/lib/fixes.ts
@@ -1,0 +1,32 @@
+// Copyright Sebastian Wiesner <sebastian@swsnr.de>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0.If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Alternatively, the contents of this file may be used under the terms
+// of the GNU General Public License Version 2 or later, as described below:
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+import type GLib from "gi://GLib";
+
+/**
+ * This module provides workarounds and fixes for various incomplete type
+ * declarations in Gnome shell types and its dependencies.
+ */
+
+/**
+ * @see https://github.com/gjsify/ts-for-gir/issues/196
+ */
+export interface GLibErrorWithStack extends GLib.Error {
+  readonly stack: string;
+}

--- a/src/lib/fixes.ts
+++ b/src/lib/fixes.ts
@@ -18,6 +18,8 @@
 // GNU General Public License for more details.
 
 import type GLib from "gi://GLib";
+import type Gio from "gi://Gio";
+import type Soup from "gi://Soup";
 
 /**
  * This module provides workarounds and fixes for various incomplete type
@@ -29,4 +31,54 @@ import type GLib from "gi://GLib";
  */
 export interface GLibErrorWithStack extends GLib.Error {
   readonly stack: string;
+}
+
+/**
+ * @see https://github.com/gjsify/ts-for-gir/issues/171#issuecomment-2117301067
+ */
+export interface PromisifiedFileOutputStream extends Gio.FileOutputStream {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  splice_async(
+    source: Gio.InputStream,
+    flags: Gio.OutputStreamSpliceFlags,
+    io_priority: number,
+    cancellable?: Gio.Cancellable | null,
+  ): Promise<ReturnType<Gio.OutputStream["splice_finish"]>>;
+}
+
+/**
+ * @see https://github.com/gjsify/ts-for-gir/issues/171#issuecomment-2117301067
+ */
+export interface PromisifiedGioFile extends Gio.File {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  create_async(
+    flags: Gio.FileCreateFlags,
+    io_priority: number,
+    cancellable?: Gio.Cancellable | null,
+  ): Promise<ReturnType<Gio.File["create_finish"]>>;
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  delete_async(
+    io_priority: number,
+    cancellable?: Gio.Cancellable | null,
+  ): Promise<ReturnType<Gio.File["delete_finish"]>>;
+}
+
+/**
+ * @see https://github.com/gjsify/ts-for-gir/issues/171#issuecomment-2117301067
+ */
+export interface PromisifiedSoupSession extends Soup.Session {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  send_async(
+    msg: Soup.Message,
+    io_priority: number,
+    cancellable?: Gio.Cancellable | null,
+  ): Promise<ReturnType<Soup.Session["send_finish"]>>;
+
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  send_and_read_async(
+    msg: Soup.Message,
+    io_priority: number,
+    cancellable?: Gio.Cancellable | null,
+  ): Promise<ReturnType<Soup.Session["send_and_read_finish"]>>;
 }

--- a/src/lib/fixes.ts
+++ b/src/lib/fixes.ts
@@ -17,9 +17,11 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
+// Only use type imports here, as this module is used in prefs as well as extension code!
 import type GLib from "gi://GLib";
 import type Gio from "gi://Gio";
 import type Soup from "gi://Soup";
+import type Gtk from "gi://Gtk";
 
 /**
  * This module provides workarounds and fixes for various incomplete type
@@ -81,4 +83,16 @@ export interface PromisifiedSoupSession extends Soup.Session {
     io_priority: number,
     cancellable?: Gio.Cancellable | null,
   ): Promise<ReturnType<Soup.Session["send_and_read_finish"]>>;
+}
+
+/**
+ * @see https://github.com/gjsify/ts-for-gir/issues/200
+ * @see https://github.com/gjsify/ts-for-gir/issues/140
+ */
+export interface PromisifiedGtkFileDialog extends Gtk.FileDialog {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  select_folder(
+    parent?: Gtk.Window | null,
+    cancellable?: Gio.Cancellable | null,
+  ): Promise<ReturnType<Gtk.FileDialog["select_folder_finish"]>>;
 }

--- a/src/lib/services/desktop-background.ts
+++ b/src/lib/services/desktop-background.ts
@@ -63,10 +63,6 @@ export class DesktopBackgroundService {
    * @param image The image file to use as new background
    */
   setBackgroundImageFile(image: Gio.File): void {
-    const uri = image.get_uri();
-    if (uri === null) {
-      throw new Error("Failed obtain URI from file");
-    }
-    this.backgroundImage = uri;
+    this.backgroundImage = image.get_uri();
   }
 }

--- a/src/lib/services/image-metadata-store.ts
+++ b/src/lib/services/image-metadata-store.ts
@@ -70,13 +70,9 @@ export class ImageMetadataStore {
    * Store metadata for the given image.
    */
   storedMetadataForImage(image: ImageFile) {
-    const uri = image.file.get_uri();
-    if (uri === null) {
-      throw new Error("Failed to get URI for current image, not storing!");
-    }
     const stored: StoredMetadata = {
       metadata: image.metadata,
-      uri: uri,
+      uri: image.file.get_uri(),
     };
     this.settings.set_string("current-metadata", JSON.stringify(stored));
   }
@@ -87,11 +83,9 @@ export class ImageMetadataStore {
    * @returns The stored image or null if no image was stored or the store was invalid
    */
   loadFromMetadata(): ImageFile | null {
-    const storedRaw = this.settings.get_string("current-metadata");
-    if (storedRaw === null) {
-      return null;
-    }
-    const stored = parseStoredMetadata(storedRaw);
+    const stored = parseStoredMetadata(
+      this.settings.get_string("current-metadata"),
+    );
     if (stored !== null) {
       return {
         metadata: stored.metadata,

--- a/src/lib/services/refresh-error-handler.ts
+++ b/src/lib/services/refresh-error-handler.ts
@@ -169,9 +169,7 @@ export class RefreshErrorHandler
       // If the inner error is a GLib error use its message instead of the wrapper message for better accuracy
       // and locatization.
       const errorMessage =
-        (error.cause instanceof GLib.Error
-          ? error.cause.message
-          : error.message) ?? "";
+        error.cause instanceof GLib.Error ? error.cause.message : error.message;
       notification.body = i18n.format(description, errorMessage);
     }
   }

--- a/src/lib/source/settings.ts
+++ b/src/lib/source/settings.ts
@@ -34,11 +34,7 @@ export class SourceSettings {
     extension: Extension,
     settings: Gio.Settings,
   ): SourceSettings {
-    const schemaId = settings.schemaId;
-    if (schemaId === null) {
-      throw new Error("Base settings have no schema ID!");
-    }
-    return new SourceSettings(extension, schemaId);
+    return new SourceSettings(extension, settings.schemaId);
   }
 
   /**

--- a/src/lib/sources/apod.ts
+++ b/src/lib/sources/apod.ts
@@ -168,7 +168,7 @@ const getImage = async (
   cancellable: Gio.Cancellable,
 ): Promise<DownloadableImage> => {
   const apiKey = settings.get_string("api-key");
-  if (apiKey === null || apiKey.length === 0) {
+  if (apiKey.length === 0) {
     throw new InvalidAPIKeyError(metadata);
   }
 

--- a/src/lib/sources/bing.ts
+++ b/src/lib/sources/bing.ts
@@ -23,7 +23,7 @@ import Soup from "gi://Soup";
 
 import metadata from "./metadata/bing.js";
 import { Source } from "../source/source.js";
-import { HttpRequestError, getJSON } from "../network/http.js";
+import { getJSON } from "../network/http.js";
 import { DownloadableImage } from "../download.js";
 import { decodeQuery, encodeQuery } from "../network/uri.js";
 
@@ -76,12 +76,6 @@ export const getTodaysImages = async (
       urlbaseUHD,
       GLib.UriFlags.NONE,
     );
-    if (imageUrl === null) {
-      throw new HttpRequestError(
-        url,
-        `Failed to join ${urlbaseUHD} to https://www.bing.com`,
-      );
-    }
     const startdate = image.startdate;
     const suggestedFilename = decodeQuery(imageUrl)["id"];
     return {

--- a/src/lib/ui/error-detail-dialog.ts
+++ b/src/lib/ui/error-detail-dialog.ts
@@ -27,6 +27,7 @@ import { pgettext } from "resource:///org/gnome/shell/extensions/extension.js";
 
 import { ModalDialog } from "resource:///org/gnome/shell/ui/modalDialog.js";
 import { unfoldCauses } from "../common/error.js";
+import { GLibErrorWithStack } from "../fixes.js";
 
 /**
  * Shortcut for `GLib.markup_escape_text`.
@@ -55,7 +56,7 @@ const formatOneError = (error: unknown): string => {
     const stack = formatStacktrace(error.stack);
     return `<b>${e(error.name)}: ${e(error.message)}</b>\n${stack}`;
   } else if (error instanceof GLib.Error) {
-    const stack = formatStacktrace(error.stack);
+    const stack = formatStacktrace((error as GLibErrorWithStack).stack);
     return `<b>${error.toString()}</b>\n${stack}`;
   } else if (typeof error === "string") {
     return e(`<b>${error}</b>`);

--- a/src/lib/ui/error-detail-dialog.ts
+++ b/src/lib/ui/error-detail-dialog.ts
@@ -31,15 +31,7 @@ import { unfoldCauses } from "../common/error.js";
 /**
  * Shortcut for `GLib.markup_escape_text`.
  */
-function e(s: string): string {
-  const escaped = GLib.markup_escape_text(s, -1);
-  if (escaped === null) {
-    // This can't happen I believe, because markup_escape_text would always return a string when given a string, but
-    // let's guard against it nonetheless.
-    throw new Error(`Failed to escape markup in ${s}`);
-  }
-  return escaped;
-}
+const e = (s: string): string => GLib.markup_escape_text(s, -1);
 
 const formatStacktrace = (stack: string | undefined): string => {
   return (
@@ -90,7 +82,7 @@ export const ErrorDetailDialog = GObject.registerClass(
   class ErrorDetailDialog extends ModalDialog {
     private readonly messageLabel: St.Label;
 
-    constructor(params?: ModalDialog.ConstructorProperties) {
+    constructor(params?: Partial<ModalDialog.ConstructorProps>) {
       super(params);
 
       const contentBox = new St.BoxLayout({

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -55,17 +55,12 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.`;
 
-const getTemplate = (name: string): string => {
-  const uri = GLib.uri_resolve_relative(
+const getTemplate = (name: string): string =>
+  GLib.uri_resolve_relative(
     import.meta.url,
     `ui/${name}.ui`,
     GLib.UriFlags.NONE,
   );
-  if (uri === null) {
-    throw new Error(`Failed to resolve URI for template ${name}!`);
-  }
-  return uri;
-};
 
 interface AllSettings {
   readonly extension: Gio.Settings;
@@ -176,9 +171,6 @@ const SourcesPage = GObject.registerClass(
         });
 
       const selectedKey = this.settings.extension.get_string("selected-source");
-      if (selectedKey === null) {
-        throw new Error("'selected-source' is null?");
-      }
       const selectedSource = buttons.get(selectedKey)?.source;
       if (typeof selectedSource === "undefined") {
         throw new Error(`${selectedKey} does not denote a known source!`);
@@ -187,9 +179,6 @@ const SourcesPage = GObject.registerClass(
       buttons.get(selectedKey)?.button.set_active(true);
       this.settings.extension.connect("changed::selected-source", () => {
         const newKey = this.settings.extension.get_string("selected-source");
-        if (newKey === null) {
-          throw new Error("'selected-source' is null?");
-        }
         const item = buttons.get(newKey);
         if (typeof item === "undefined") {
           throw new Error(`Source ${newKey} not known?`);
@@ -303,9 +292,6 @@ export default class PictureOfTheDayPreferences extends ExtensionPreferences {
     // Load relevant settings
     const extensionSettings = this.getSettings();
     const schema_id = extensionSettings.schemaId;
-    if (schema_id === null) {
-      throw new Error("Schema ID of settings schema unexpectedly null?");
-    }
     const allSettings: AllSettings = {
       extension: extensionSettings,
       sourceAPOD: this.getSettings(`${schema_id}.source.${apod.key}`),


### PR DESCRIPTION
Does not build currently, as the 4.x types still suffer from regressions, notably

- Missing promisified overloads: https://github.com/gjsify/ts-for-gir/issues/171
- Missing GLib.Error.stack: https://github.com/gjsify/ts-for-gir/issues/196